### PR TITLE
add hack for sharing property link

### DIFF
--- a/src/app/api/share/[id]/route.ts
+++ b/src/app/api/share/[id]/route.ts
@@ -1,0 +1,55 @@
+import { NextRequest } from "next/server";
+import { getPropertyLight } from "@/lib/getPropertyLight";
+
+//this is a hacky solution to make sure that the bots can scrape to see the peoperty information, but at the same time real users get redirected to the actual property.(aws amplify does not work with generateMetadata.)
+export async function GET(
+  _req: NextRequest,
+  { params }: { params: { id: string } }
+) {
+  const { id } = await params;
+  const meta = await getPropertyLight(id);
+  const name = meta?.name ?? "Property Listing";
+  const description =
+    meta?.description ?? "Voyage | find your perfect property";
+  const image = meta?.photoUrlsBaseKeys?.[0] ?? "/default-property.jpg";
+  const url = `${process.env.NEXT_PUBLIC_SITE_URL}/search/${id}`;
+
+  // Always return HTML with meta tags, but redirect users immediately
+  const html = `
+    <!DOCTYPE html>
+    <html lang="en">
+    <head>
+      <meta charset="utf-8" />
+      <title>${name}</title>
+      <meta name="description" content="${description}" />
+      <!-- Open Graph -->
+      <meta property="og:title" content="${name}" />
+      <meta property="og:description" content="${description}" />
+      <meta property="og:image" content="${image}" />
+      <meta property="og:type" content="website" />
+      <meta property="og:url" content="${url}" />
+      <!-- Twitter -->
+      <meta name="twitter:card" content="summary_large_image" />
+      <meta name="twitter:title" content="${name}" />
+      <meta name="twitter:description" content="${description}" />
+      <meta name="twitter:image" content="${image}" />
+      
+      <!-- Meta refresh as fallback -->
+      <meta http-equiv="refresh" content="0;url=${url}" />
+    </head>
+    <body>
+      <h1>${name}</h1>
+      <p>Redirecting to property...</p>
+      <script>
+        // Immediate redirect for users with JavaScript
+        window.location.replace('${url}');
+      </script>
+      <noscript>
+        <a href="${url}">Click here if you are not redirected automatically</a>
+      </noscript>
+    </body>
+    </html>
+  `;
+
+  return new Response(html, { headers: { "Content-Type": "text/html" } });
+}

--- a/src/app/share/[id]/page.tsx
+++ b/src/app/share/[id]/page.tsx
@@ -1,0 +1,5 @@
+import { redirect } from "next/navigation";
+
+export default function Page({ params }: { params: { id: string } }) {
+  redirect(`/api/share/${params.id}`);
+}

--- a/src/components/Card.tsx
+++ b/src/components/Card.tsx
@@ -1,7 +1,8 @@
 import React, { useState } from "react";
 import Image from "next/image";
-import { Bath, Bed, Heart, House, Star } from "lucide-react";
+import { Bath, Bed, Heart, House, Star, Share2 } from "lucide-react";
 import Link from "next/link";
+import { handleShare } from "@/lib/utils";
 
 const Card = ({
   property,
@@ -13,6 +14,7 @@ const Card = ({
   const [imgSrc, setImgSrc] = useState(
     property.photoUrlsBaseKeys?.[0] || "/placeholder.jpg"
   );
+
   return (
     <div className="bg-white rounded-xl overflow-hidden shadow-lg w-full mb-5">
       <div className="relative">
@@ -38,18 +40,30 @@ const Card = ({
             </span>
           )}
         </div>
-        {showFavoriteButton && (
+        <div className="absolute bottom-4 right-4 flex gap-2">
           <button
-            className="absolute bottom-4 right-4 bg-white hover:bg-white/90 rounded-full p-2 cursor-pointer"
-            onClick={onFavoriteToggle}
+            className="bg-white hover:bg-white/90 rounded-full p-2 cursor-pointer"
+            onClick={async () => {
+              await handleShare(property.id.toString());
+            }}
+            title="Share property"
           >
-            <Heart
-              className={`w-5 h-5 ${
-                isFavorite ? "text-red-500 fill-red-500" : "text-gray-600"
-              }`}
-            />
+            <Share2 className="w-5 h-5 text-gray-600" />
           </button>
-        )}
+          {showFavoriteButton && (
+            <button
+              className="bg-white hover:bg-white/90 rounded-full p-2 cursor-pointer"
+              onClick={onFavoriteToggle}
+              title={isFavorite ? "Remove from favorites" : "Add to favorites"}
+            >
+              <Heart
+                className={`w-5 h-5 ${
+                  isFavorite ? "text-red-500 fill-red-500" : "text-gray-600"
+                }`}
+              />
+            </button>
+          )}
+        </div>
       </div>
       <div className="p-4">
         <h2 className="text-xl font-bold mb-1">

--- a/src/components/PropertyOverview.tsx
+++ b/src/components/PropertyOverview.tsx
@@ -3,7 +3,8 @@ import { useParams } from "next/navigation";
 import React, { useEffect, useState } from "react";
 import Loading from "./Loading";
 import Image from "next/image";
-import { Bath, Bed, Home, MapPin, Users } from "lucide-react";
+import { Bath, Bed, Home, MapPin, Users, Share2 } from "lucide-react";
+import { handleShare } from "@/lib/utils";
 
 const PropertyOverview = () => {
   const { id } = useParams();
@@ -35,10 +36,19 @@ const PropertyOverview = () => {
         sizes="(max-width: 768px) 100vw, (max-width: 1200px) 50vw, 33vw"
         onError={() => setImgSrc("/placeholder.jpg")}
       />
-      {/* <div className="w-64 h-32 object-cover bg-slate-500 rounded-xl" /> */}
       <div className="flex flex-col justify-between flex-1">
         <div>
-          <h2 className="text-2xl font-bold my-2">{property.name}</h2>
+          <div className="flex justify-between items-start mb-2">
+            <h2 className="text-2xl font-bold">{property.name}</h2>
+            <button
+              className={`bg-white border border-gray-300 text-gray-700 py-2
+              px-4 rounded-md flex items-center justify-center hover:bg-primary-700 hover:text-primary-50 transition-colors cursor-pointer`}
+              onClick={async () => handleShare(id?.toString() || "")}
+            >
+              <Share2 className="w-4 h-4 mr-2" />
+              <span>Share This Property</span>
+            </button>
+          </div>
           <div className="flex items-center mb-2 text-gray-600">
             <MapPin className="w-5 h-5 mr-1" />
             <span>

--- a/src/components/search/ContactWidget.tsx
+++ b/src/components/search/ContactWidget.tsx
@@ -1,10 +1,12 @@
 import { Button } from "@/components/ui/button";
 import { useGetAuthUserQuery } from "@/state/api/authEndpoints";
 import { useGetPropertyQuery } from "@/state/api/propertyEndpoints";
-import { Phone } from "lucide-react";
+import { Phone, Share2 } from "lucide-react";
 import { useRouter } from "next/navigation";
 import React from "react";
 import Loading from "../Loading";
+import { toast } from "sonner";
+import { handleShare } from "@/lib/utils";
 
 const ContactWidget = ({ propertyId, onOpenModal }: ContactWidgetProps) => {
   const { data: authUser } = useGetAuthUserQuery();
@@ -24,26 +26,50 @@ const ContactWidget = ({ propertyId, onOpenModal }: ContactWidgetProps) => {
     }
   };
 
+  const handlePhoneClick = async () => {
+    const phoneNumber = property?.manager?.phoneNumber;
+    if (phoneNumber) {
+      try {
+        await navigator.clipboard.writeText(phoneNumber);
+        toast.success("Phone number copied successfully!");
+      } catch (error) {
+        console.log(error);
+        toast.error("Failed to copy phone number");
+      }
+    }
+  };
+
   if (isLoading) return <Loading />;
   if (isError) return <>Failed to fetch manager contact</>;
 
   return (
     <div className="bg-white border border-primary-200 rounded-2xl p-7 h-fit min-w-[300px]">
       {/* Contact Property */}
-      <div className="flex items-center gap-5 mb-4 border border-primary-200 p-4 rounded-xl">
-        <div className="flex items-center p-4 bg-primary-900 rounded-full">
-          <Phone className="text-primary-50" size={15} />
-        </div>
-        <div>
-          <p>Contact This Property</p>
-          <div
-            className="text-lg font-bold text-primary-800 cursor-pointer"
-            title="Manager phone number"
-          >
-            {property?.manager?.phoneNumber}
+      {property?.manager?.phoneNumber && (
+        <div className="flex items-center gap-5 mb-4 border border-primary-200 p-4 rounded-xl">
+          <div className="flex items-center p-4 bg-primary-900 rounded-full">
+            <Phone className="text-primary-50" size={15} />
+          </div>
+          <div>
+            <p>Contact This Property</p>
+            <div
+              className="text-lg font-bold text-primary-800 cursor-pointer hover:text-primary-600 transition-colors"
+              title="Click to copy phone number"
+              onClick={handlePhoneClick}
+            >
+              {property.manager.phoneNumber}
+            </div>
           </div>
         </div>
-      </div>
+      )}
+      <Button
+        variant="outline"
+        className="w-full mb-4 border-primary-200 text-primary-700 hover:bg-primary-50 cursor-pointer"
+        onClick={async () => handleShare(propertyId.toString())}
+      >
+        <Share2 className="mr-2 h-4 w-4" />
+        Share This Property
+      </Button>
       <Button
         className="w-full bg-primary-700 text-white hover:bg-primary-600"
         onClick={handleButtonClick}

--- a/src/components/search/Map.tsx
+++ b/src/components/search/Map.tsx
@@ -24,7 +24,7 @@ const Map = () => {
       container: mapContainerRef.current!,
       style: "mapbox://styles/duttabhay/cmay2omma009a01qxcu81dcpg",
       center: filters.coordinates || [-74.5, 40],
-      zoom: 9,
+      zoom: 12,
     });
 
     properties.forEach((property) => {

--- a/src/lib/getPropertyLight.ts
+++ b/src/lib/getPropertyLight.ts
@@ -1,0 +1,23 @@
+import { Property, Location } from "@/types/prismaTypes";
+
+export type PropertyLight = Pick<
+  Property,
+  "name" | "description" | "pricePerNight" | "photoUrlsBaseKeys"
+> & {
+  location: Pick<Location, "state" | "city" | "country">;
+};
+
+export async function getPropertyLight(
+  id: string
+): Promise<PropertyLight | null> {
+  const res = await fetch(
+    `${process.env.NEXT_PUBLIC_API_BASE_URL}/properties/${id}/light`,
+    {
+      cache: "force-cache", // property data will never be changes, hence can cache the data forever.
+    }
+  );
+
+  if (!res.ok) return null;
+
+  return res.json();
+}

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -125,3 +125,14 @@ export const debounce = <T extends (...args: any[]) => void>(
     }, delay);
   };
 };
+
+export const handleShare = async (propertyId: string) => {
+  const shareUrl = `${window.location.origin}/api/share/${propertyId}`;
+  try {
+    await navigator.clipboard.writeText(shareUrl);
+    toast.success("Link copied successfully!");
+  } catch (error) {
+    console.log(error);
+    toast.error("Failed to copy link");
+  }
+};

--- a/src/state/api/propertyEndpoints.ts
+++ b/src/state/api/propertyEndpoints.ts
@@ -101,11 +101,8 @@ export const propertyApi = baseApi.injectEndpoints({
       Pick<Lease, "propertyId">
     >({
       query: (params) => ({
-        url: "leases/getAcceptedLeases",
+        url: `properties/${params.propertyId}/leases/times`,
         method: "GET",
-        params: {
-          propertyId: params.propertyId,
-        },
       }),
     }),
     reviewLeaseProperty: build.mutation<
@@ -113,7 +110,7 @@ export const propertyApi = baseApi.injectEndpoints({
       { leaseId: number; propertyId: number; reviewRating: number }
     >({
       query: (reviewBody) => ({
-        url: "leases/reviewLeaseProperty",
+        url: `properties/${reviewBody.propertyId}/${reviewBody.leaseId}/reviews`,
         method: "POST",
         body: reviewBody,
       }),


### PR DESCRIPTION
aws amplify does not work with generate metadata (nextjs)
this is a hacky solution to make sure that bots can scrape the details about the property.